### PR TITLE
No need to set python_min when it is less than 3.10

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,13 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- 3.12.* *_cpython
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 python_min:
 - '3.9'
 pytorch:

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "mistral-inference" %}
 {% set version = "1.5.0" %}
-{% set python_min = python_min|default("3.8") %}
 
 package:
   name: {{ name|lower }}
@@ -11,8 +10,8 @@ source:
   sha256: 0fdc290d5b960ebb43a5cbfdb70d74cdd901c8927c0f0ffd24cf6072f127638c
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 1
+  script: {{ PYTHON }} -m pip install . -vv
   noarch: python
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
